### PR TITLE
Fix czech translation of index.md title

### DIFF
--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -1,5 +1,5 @@
 ---
-title: Přihlášení v .NET Core a ASP.NET Core
+title: Protokolování v .NET Core a ASP.NET Core
 author: rick-anderson
 description: Naučte se používat protokolovací rozhraní poskytovanou balíčkem NuGet Microsoft. Extensions. Logging.
 monikerRange: '>= aspnetcore-2.1'


### PR DESCRIPTION
Fixed translation of the document title - "Logging" was translated as "Signing-In".
Note the body seems to use the correct term.